### PR TITLE
fix: skip stub error when NODE_ENV=production or STRAPI_TYPES_SKIP_CH…

### DIFF
--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -137,6 +137,8 @@ The client uses the global `fetch` by default. In Next.js, this means you automa
 
 ::: tip What if I skip the generate step?
 The package ships with a stub that lets `import { StrapiClient } from 'strapi-typed-client'` resolve without errors. However, creating a `StrapiClient` instance will throw a clear error reminding you to run `npx strapi-types generate`.
+
+The error is skipped when `NODE_ENV === 'production'`. For other environments like staging, set `STRAPI_TYPES_SKIP_CHECK=true` to opt out.
 :::
 
 ## Next Steps

--- a/src/index.ts
+++ b/src/index.ts
@@ -43,8 +43,14 @@ export class StrapiConnectionError extends Error {
     }
 }
 
+const SKIP_STUB_CHECK =
+    process.env.NODE_ENV === 'production' ||
+    process.env.STRAPI_TYPES_SKIP_CHECK === 'true'
+
 export class StrapiClient {
     constructor(_config: { baseURL: string; token?: string }) {
-        throw new Error(NOT_GENERATED_MESSAGE)
+        if (!SKIP_STUB_CHECK) {
+            throw new Error(NOT_GENERATED_MESSAGE)
+        }
     }
 }


### PR DESCRIPTION
Hello! 👋 

Right now the stub throws whenever `new StrapiClient()` is called and types haven't been generated. That makes sense locally, but it's annoying in CI/staging environments where you don't need types at runtime (they're stripped at compile time anyway).

This PR skips the throw when `NODE_ENV === 'production'` or `STRAPI_TYPES_SKIP_CHECK === 'true'`, so you can opt out per environment without having to run `strapi-types generate` just to silence it.