### PR TITLE
docs(nextjs): update Next.js integration docs

### DIFF
--- a/docs/advanced/single-types.md
+++ b/docs/advanced/single-types.md
@@ -154,11 +154,12 @@ const landing = await strapi.landing.find(
 A complete example fetching and rendering a landing page in Next.js:
 
 ```typescript
-import { StrapiClient } from '@myapp/strapi-types';
+import { StrapiClient } from 'strapi-typed-client'
 
 const strapi = new StrapiClient({
-  baseURL: process.env.NEXT_PUBLIC_STRAPI_URL!,
-});
+    baseURL: process.env.NEXT_PUBLIC_STRAPI_URL ?? 'http://localhost:1337',
+    token: process.env.STRAPI_TOKEN,
+})
 
 export default async function LandingPage() {
   const { data: landing } = await strapi.landing.find({

--- a/docs/guide/nextjs.md
+++ b/docs/guide/nextjs.md
@@ -14,11 +14,10 @@ const nextConfig = {
     // your existing Next.js config
 }
 
-export default withStrapiTypes(nextConfig, {
-    url: process.env.STRAPI_URL || 'http://localhost:1337',
-    token: process.env.STRAPI_TOKEN,
-    output: './src/strapi',
-})
+export default withStrapiTypes({
+    strapiUrl: process.env.NEXT_PUBLIC_STRAPI_URL ?? 'http://localhost:1337',
+    token: process.env.STRAPI_API_TOKEN,
+})(nextConfig)
 ```
 
 ### Behavior
@@ -136,10 +135,10 @@ In a Next.js App Router Server Component:
 
 ```tsx
 // app/articles/page.tsx
-import { StrapiClient } from '@/strapi'
+import { StrapiClient } from 'strapi-typed-client'
 
 const strapi = new StrapiClient({
-    baseURL: process.env.STRAPI_URL!,
+    baseURL: process.env.NEXT_PUBLIC_STRAPI_URL ?? 'http://localhost:1337',
     token: process.env.STRAPI_TOKEN,
 })
 
@@ -174,11 +173,11 @@ Use the client in Server Actions for mutations:
 // app/articles/actions.ts
 'use server'
 
-import { StrapiClient } from '@/strapi'
+import { StrapiClient } from 'strapi-typed-client'
 import { revalidateTag } from 'next/cache'
 
 const strapi = new StrapiClient({
-    baseURL: process.env.STRAPI_URL!,
+    baseURL: process.env.NEXT_PUBLIC_STRAPI_URL ?? 'http://localhost:1337',
     token: process.env.STRAPI_TOKEN,
 })
 

--- a/docs/guide/nextjs.md
+++ b/docs/guide/nextjs.md
@@ -17,8 +17,6 @@ const nextConfig = {
 export default withStrapiTypes({
     strapiUrl: process.env.NEXT_PUBLIC_STRAPI_URL ?? 'http://localhost:1337',
     token: process.env.STRAPI_TOKEN,
-    format: 'ts',
-    output: './src/strapi'
 })(nextConfig)
 ```
 
@@ -52,7 +50,18 @@ export default withStrapiTypes({
 })(nextConfig)
 ```
 
-Your `tsconfig.json` needs `moduleResolution: "bundler"` or `"nodenext"` so `.js`-extension imports inside the generated client resolve to `.ts` source (the Next.js default already satisfies this).
+Then import from `@/strapi` (the `create-next-app` default `@/*` → `./src/*` path alias maps it to your output dir):
+
+```ts
+import { StrapiClient } from '@/strapi'
+
+const strapi = new StrapiClient({
+    baseURL: process.env.NEXT_PUBLIC_STRAPI_URL ?? 'http://localhost:1337',
+    token: process.env.STRAPI_TOKEN,
+})
+```
+
+Your `tsconfig.json` needs `moduleResolution: "bundler"` (the Next.js default) so the extensionless local imports inside the generated client resolve.
 
 ::: tip
 This replaces the need to run `strapi-types watch` or `strapi-types generate` manually. The wrapper handles everything.


### PR DESCRIPTION
## Description

This PR updates the Next.js integration documentation to reflect the current, recommended usage of ‎`strapi-typed-client`. It adjusts the examples to:

- Import ‎`StrapiClient` directly from ‎`strapi-typed-client`
- Use ‎`NEXT_PUBLIC_STRAPI_URL` with a sensible localhost fallback
- Configure and demonstrate the ‎`withStrapiTypes` wrapper using the correct options
- Keep the import style and environment variables consistent across the Next.js guide and the single types example

## Type of change

- [X] Documentation update
- [ ] Bug fix
- [ ] New feature
- [ ] Refactoring (no behavior change)
- [ ] Other (describe below)

## Checklist

- [X] Code follows the project's conventions
- [X] `yarn build` passes
- [X] `yarn test` passes
- [X] Documentation updated (if applicable)
- [ ] Tests added/updated (if applicable)
