### PR TITLE
fix(generator): disambiguate standalone controller / content type pluralName collisions

### DIFF
--- a/src/generator/client-generator.ts
+++ b/src/generator/client-generator.ts
@@ -4,7 +4,7 @@ import { createRequire } from 'module'
 import { Project, SourceFile } from 'ts-morph'
 import { ParsedSchema, ContentType } from '../schema-types.js'
 import { AuthApiGenerator } from './auth-api-generator.js'
-import type { ParsedRoutes } from '../shared/route-types.js'
+import type { ParsedRoute, ParsedRoutes } from '../shared/route-types.js'
 import { CustomApiGenerator } from './custom-api-generator.js'
 import { toCamelCase, toPascalCase } from '../shared/index.js'
 import type {
@@ -914,7 +914,11 @@ ${customMethods}
                 )
             } else {
                 // Standalone API class (no content type)
-                const className = toPascalCase(controller) + 'API'
+                const { className } = this.resolveStandaloneNames(
+                    controller,
+                    routes,
+                    schema,
+                )
                 const customMethods =
                     this.customApiGenerator.generateCustomMethods(
                         controller,
@@ -1099,6 +1103,42 @@ ${standaloneInits}
 }`
     }
 
+    /**
+     * Resolve the class + property name for a standalone controller (one that
+     * does not correspond to a content type).
+     *
+     * A plugin-route controller can share a name with another content type's
+     * pluralName — e.g. the users-permissions plugin's `permissions` controller
+     * (which serves /api/users-permissions/permissions) vs a `Permission`
+     * content type whose pluralName is `permissions` (which serves
+     * /api/permissions). These are two distinct endpoints, and we want both on
+     * the client. When this collision occurs, disambiguate the standalone name
+     * by prefixing it with the plugin's camelCase name.
+     */
+    private resolveStandaloneNames(
+        controller: string,
+        routes: ParsedRoute[],
+        schema: ParsedSchema,
+    ): { className: string; propName: string } {
+        const collides = schema.contentTypes.some(
+            ct => ct.pluralName === controller,
+        )
+        const pluginName = routes.find(r => r.pluginName)?.pluginName
+
+        if (collides && pluginName) {
+            return {
+                className:
+                    toPascalCase(pluginName) + toPascalCase(controller) + 'API',
+                propName: toCamelCase(pluginName) + toPascalCase(controller),
+            }
+        }
+
+        return {
+            className: toPascalCase(controller) + 'API',
+            propName: toCamelCase(controller),
+        }
+    }
+
     private buildStandaloneDeclarations(
         schema: ParsedSchema,
         parsedRoutes?: ParsedRoutes,
@@ -1106,7 +1146,7 @@ ${standaloneInits}
         if (!parsedRoutes) return ''
 
         const declarations: string[] = []
-        for (const [controller] of parsedRoutes.byController) {
+        for (const [controller, routes] of parsedRoutes.byController) {
             if (controller === 'auth' || controller === 'user') continue
 
             const hasContentType = schema.contentTypes.some(
@@ -1114,8 +1154,11 @@ ${standaloneInits}
             )
 
             if (!hasContentType) {
-                const className = toPascalCase(controller) + 'API'
-                const propName = toCamelCase(controller)
+                const { className, propName } = this.resolveStandaloneNames(
+                    controller,
+                    routes,
+                    schema,
+                )
                 declarations.push(`  ${propName}: ${className}`)
             }
         }
@@ -1130,7 +1173,7 @@ ${standaloneInits}
         if (!parsedRoutes) return ''
 
         const inits: string[] = []
-        for (const [controller] of parsedRoutes.byController) {
+        for (const [controller, routes] of parsedRoutes.byController) {
             if (controller === 'auth' || controller === 'user') continue
 
             const hasContentType = schema.contentTypes.some(
@@ -1138,8 +1181,11 @@ ${standaloneInits}
             )
 
             if (!hasContentType) {
-                const className = toPascalCase(controller) + 'API'
-                const propName = toCamelCase(controller)
+                const { className, propName } = this.resolveStandaloneNames(
+                    controller,
+                    routes,
+                    schema,
+                )
                 inits.push(
                     `    this.${propName} = new ${className}(this.config)`,
                 )

--- a/tests/unit/generator/client-generator.test.ts
+++ b/tests/unit/generator/client-generator.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest'
 import { ClientGenerator } from '../../../src/generator/client-generator.js'
 import type { ParsedSchema } from '../../../src/schema-types.js'
+import type { ParsedEndpoint } from '../../../src/shared/endpoint-types.js'
 
 const mockSchema: ParsedSchema = {
     contentTypes: [
@@ -565,6 +566,75 @@ describe('ClientGenerator', () => {
                 output.indexOf('class AuthAPI extends BaseAPI'),
             )
             expect(authSection).toContain('data: Partial<User>,')
+        })
+    })
+
+    describe('Standalone controller / content type pluralName collisions', () => {
+        // Reproduces the case where the users-permissions plugin exposes a
+        // standalone `permissions` controller (/api/users-permissions/permissions)
+        // AND the project has a `Permission` content type whose pluralName is
+        // also `permissions` (/api/permissions). These are two distinct
+        // endpoints — both should be callable from the client. Without
+        // disambiguation the generator emits `permissions` twice on
+        // StrapiClient, producing a "Duplicate member" esbuild error.
+        const schema: ParsedSchema = {
+            contentTypes: [
+                {
+                    name: 'PluginUsersPermissionsPermission',
+                    cleanName: 'Permission',
+                    collectionName: 'up_permissions',
+                    singularName: 'permission',
+                    pluralName: 'permissions',
+                    kind: 'collection',
+                    attributes: [
+                        {
+                            name: 'action',
+                            type: { kind: 'string' },
+                            required: true,
+                        },
+                    ],
+                    relations: [],
+                    media: [],
+                    components: [],
+                    dynamicZones: [],
+                },
+            ],
+            components: [],
+        }
+
+        const endpoints: ParsedEndpoint[] = [
+            {
+                method: 'GET',
+                path: '/permissions',
+                handler: 'plugin::users-permissions.permissions.getPermissions',
+                controller: 'permissions',
+                action: 'getPermissions',
+                pluginName: 'users-permissions',
+            },
+        ]
+
+        const result = new ClientGenerator().generate(schema, endpoints)
+        const clientSection = result.slice(
+            result.indexOf('export class StrapiClient'),
+        )
+
+        it('should emit the content type collection property exactly once', () => {
+            const permissionsDeclarations =
+                clientSection.match(/^\s*permissions:\s/gm) ?? []
+            expect(permissionsDeclarations.length).toBe(1)
+        })
+
+        it('should preserve the standalone plugin endpoint under a disambiguated name', () => {
+            // The standalone class is still emitted (under a plugin-prefixed
+            // name) so the /api/users-permissions/permissions endpoint remains
+            // callable — we only rename to avoid the property collision.
+            expect(result).toContain('class UsersPermissionsPermissionsAPI')
+            expect(clientSection).toContain(
+                'usersPermissionsPermissions: UsersPermissionsPermissionsAPI',
+            )
+            expect(clientSection).toContain(
+                'this.usersPermissionsPermissions = new UsersPermissionsPermissionsAPI(this.config)',
+            )
         })
     })
 })


### PR DESCRIPTION
## Description

Fixes #41.

When a plugin-route controller shares a name with a content type's `pluralName`, the generated `StrapiClient` class emitted two members with the same name. Most commonly this happens with the users-permissions plugin: the standalone `permissions` controller (GET `/permissions` → `getPermissions`) collides with the `Permission` content type's pluralName `permissions`. The generated `client.ts` ended up with:

```ts
permissions: CollectionAPI<Permission, ...>
// ...
permissions: PermissionsAPI   // duplicate
```

esbuild reports this as `Duplicate member "permissions" in class body`, and at runtime the constructor overwrote the collection slot with `PermissionsAPI`, so `client.permissions.find()` against `/api/permissions` stopped working.

### Root cause

Three locations in `client-generator.ts` decided "is this controller a content type or standalone?" by matching only on `singularName`:

- `generateCustomAPIClasses`
- `buildStandaloneDeclarations`
- `buildStandaloneInits`

But collection-type property slots on `StrapiClient` are named after `pluralName` (`generateStrapiClient`), so when a standalone controller's name equals any content type's `pluralName`, the two slots collide.

### Fix

I considered three options:

1. **Drop** the standalone class when it collides — loses functionality (`getPermissions()` is no longer callable).
2. **Merge** the routes into the content-type CollectionAPI — incorrect, because the URLs are genuinely different (`/api/permissions` vs `/api/users-permissions/permissions`).
3. **Rename** the standalone class + property using the plugin name as a prefix — keeps both endpoints, preserves the package's intent.

This PR implements (3). A new `resolveStandaloneNames` helper centralizes the naming decision: when a collision is detected and the controller came from a plugin, it returns e.g. `{ className: 'UsersPermissionsPermissionsAPI', propName: 'usersPermissionsPermissions' }`. Non-colliding standalone controllers are unchanged, so this is backwards-compatible for every setup that wasn't already broken.

Before (broken):
```ts
permissions: CollectionAPI<Permission, ...>
permissions: PermissionsAPI   // duplicate ❌
```

After:
```ts
permissions: CollectionAPI<Permission, ...>                   // /api/permissions
usersPermissionsPermissions: UsersPermissionsPermissionsAPI   // /api/users-permissions/permissions
```

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactoring (no behavior change)
- [ ] Documentation update
- [ ] Other (describe below)

## Checklist

- [x] Code follows the project's conventions
- [x] Tests added/updated (if applicable) — new `describe` block in `tests/unit/generator/client-generator.test.ts` covers the collision case, asserting both the collection slot is emitted exactly once and the disambiguated standalone name is present
- [x] `yarn build` passes
- [x] `yarn test` passes (244 tests)
- [ ] Documentation updated (if applicable) — no user-facing API change