### PR TITLE
feat(cli): support --format on the watch command

### DIFF
--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -104,7 +104,7 @@ Pass `--output` to point at the directory you generated into. It is required.
 Connects to the Strapi SSE stream and automatically regenerates types when the schema changes.
 
 ```bash
-npx strapi-types watch --url http://localhost:1337
+npx strapi-types watch --url http://localhost:1337 --output ./src/strapi
 ```
 
 This is useful during development. The command runs continuously and:
@@ -113,6 +113,30 @@ This is useful during development. The command runs continuously and:
 2. Receives the current schema hash on connect
 3. Regenerates types only when the hash differs from the local one
 4. Automatically reconnects if the Strapi server restarts
+
+**Options:**
+
+| Option           | Description                                                                                | Default                                          |
+| ---------------- | ------------------------------------------------------------------------------------------ | ------------------------------------------------ |
+| `--url`          | Strapi server URL                                                                          | `STRAPI_URL` env or `http://localhost:1337`      |
+| `--token`        | API token for authenticated access                                                         | `STRAPI_TOKEN` env var                           |
+| `--output`       | Output directory for generated files                                                       | required (your source tree, e.g. `./src/strapi`) |
+| `--silent`       | Suppress regeneration messages                                                             | `false`                                          |
+| `--format`       | Output format: `js` (compiled `.js` + `.d.ts`) or `ts` (raw `.ts`)                         | `js`                                             |
+| `--no-typecheck` | Write output even if it fails type-checking (escape hatch for strict-only false positives) | type-checking on                                 |
+
+Each regeneration goes through `generate`, so the options above behave exactly as they do there.
+
+::: warning Match `--format` to how you generated
+`watch` regenerates in whatever format you pass it, defaulting to `js`. If your committed output is `.ts`, run `watch --format ts` — otherwise each regeneration writes `.js` + `.d.ts` alongside your `.ts` sources and leaves the `.ts` files stale.
+:::
+
+**Example:**
+
+```bash
+# Keep raw .ts output in sync during development
+npx strapi-types watch --output ./src/strapi --format ts
+```
 
 ::: tip
 For Next.js projects, consider using the `withStrapiTypes` wrapper instead of running `watch` manually. See the [Next.js guide](/guide/nextjs).

--- a/src/cli/commands/watch.ts
+++ b/src/cli/commands/watch.ts
@@ -13,6 +13,7 @@ export interface WatchOptions {
     token?: string
     output?: string
     silent?: boolean
+    format?: 'js' | 'ts'
     typecheck?: boolean
 }
 
@@ -48,6 +49,7 @@ export async function watch(options: WatchOptions): Promise<void> {
             token: options.token,
             output: outputDir,
             silent: options.silent,
+            format: options.format,
             typecheck: options.typecheck,
         })
     }
@@ -79,6 +81,7 @@ export async function watch(options: WatchOptions): Promise<void> {
                         token: options.token,
                         output: outputDir,
                         silent: true,
+                        format: options.format,
                         typecheck: options.typecheck,
                     })
 
@@ -122,6 +125,19 @@ export async function watch(options: WatchOptions): Promise<void> {
 }
 
 /**
+ * Raw option shape handed over by commander. `format` arrives as a plain
+ * string, so it is validated before being narrowed into WatchOptions.
+ */
+interface WatchCliOptions {
+    url?: string
+    token?: string
+    output?: string
+    silent?: boolean
+    format?: string
+    typecheck?: boolean
+}
+
+/**
  * CLI handler for watch command
  */
 export function createWatchCommand(program: Command): void {
@@ -144,16 +160,29 @@ export function createWatchCommand(program: Command): void {
         )
         .option('-s, --silent', 'Suppress regeneration messages')
         .option(
+            '--format <js|ts>',
+            'Output format: js (compiled .js + .d.ts, default) or ts (raw .ts for monorepo/source-tree output)',
+            'js',
+        )
+        .option(
             '--no-typecheck',
             'Write regenerated types even if they fail type-checking (escape hatch for strict-only false positives)',
         )
-        .action(async (opts: WatchOptions) => {
+        .action(async (opts: WatchCliOptions) => {
+            if (opts.format && opts.format !== 'js' && opts.format !== 'ts') {
+                console.error(
+                    `Invalid --format value: ${opts.format}. Expected 'js' or 'ts'.`,
+                )
+                process.exit(1)
+            }
+
             try {
                 await watch({
                     url: opts.url,
                     token: opts.token,
                     output: opts.output,
                     silent: opts.silent,
+                    format: opts.format as 'js' | 'ts' | undefined,
                     typecheck: opts.typecheck,
                 })
             } catch (err) {

--- a/tests/unit/cli/watch-format.test.ts
+++ b/tests/unit/cli/watch-format.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { Command } from 'commander'
+
+// generate() is the only thing watch() does with the format option, so the
+// assertion is simply: whatever format watch was given reaches generate.
+const generateMock = vi.hoisted(() =>
+    vi.fn(async () => ({ success: true, filesWritten: [] })),
+)
+
+vi.mock('../../../src/cli/commands/generate.js', () => ({
+    generate: generateMock,
+}))
+
+// Keep watch() offline and stop it before it opens an SSE connection: the
+// initial generation happens first, which is what these tests inspect.
+vi.mock('../../../src/cli/utils/api-client.js', () => ({
+    createApiClient: () => ({
+        ping: async () => true,
+        sseUrl: 'http://localhost:1337/sse',
+        getHeaders: () => ({}),
+    }),
+}))
+
+vi.mock('../../../src/shared/sse-client.js', () => ({
+    SseConnection: class {
+        connect() {}
+        close() {}
+    },
+}))
+
+// No client.ts/client.js on disk => no local hash => watch generates initially.
+vi.mock('../../../src/cli/utils/file-writer.js', async importOriginal => ({
+    ...(await importOriginal<object>()),
+    readLocalSchemaHash: () => null,
+}))
+
+const { watch, createWatchCommand } =
+    await import('../../../src/cli/commands/watch.js')
+
+describe('watch --format', () => {
+    beforeEach(() => {
+        generateMock.mockClear()
+    })
+
+    it('forwards format: ts to generate on the initial generation', async () => {
+        await watch({ output: './src/strapi', format: 'ts' })
+
+        expect(generateMock).toHaveBeenCalledOnce()
+        expect(generateMock.mock.calls[0][0]).toMatchObject({
+            output: './src/strapi',
+            format: 'ts',
+        })
+    })
+
+    it('leaves format undefined when not given, so generate defaults to js', async () => {
+        await watch({ output: './src/strapi' })
+
+        expect(generateMock.mock.calls[0][0].format).toBeUndefined()
+    })
+
+    it('registers --format on the watch command', () => {
+        const program = new Command()
+        createWatchCommand(program)
+
+        const watchCmd = program.commands.find(c => c.name() === 'watch')
+        const formatOpt = watchCmd?.options.find(o => o.long === '--format')
+
+        expect(formatOpt).toBeDefined()
+        expect(formatOpt?.flags).toBe('--format <js|ts>')
+    })
+})
+
+afterEach(() => {
+    vi.restoreAllMocks()
+})


### PR DESCRIPTION
Closes #82.

`watch` calls `generate()` internally but never forwarded `format`, so every watch-triggered regeneration hit `generate`'s `js` default. In a `--format ts` project the watcher wrote compiled `.js` + `.d.ts` alongside the committed `.ts` sources and left those sources stale — and because `readLocalSchemaHash` prefers `client.ts`, the stale hash kept winning and the mismatch never resolved itself.

### Changes

- `WatchOptions` gains `format?: 'js' | 'ts'`, forwarded at both `generate()` call sites (initial generation and the SSE `onEvent` handler)
- `--format <js|ts>` registered on the watch command, with the same validation and error message `generate` uses for an invalid value
- `WatchCliOptions` added for commander's raw string-typed option shape, mirroring `GenerateCliOptions`
- CLI reference gains an options table for `watch`, plus a note to match `--format` to how the output was generated

This follows the same passthrough shape as `a9d37cd`, which threaded `typecheck` through in exactly this way. `format` stays `undefined` when not passed, so `generate`'s `?? 'js'` default is untouched and existing behaviour is unchanged.

### Tests

Added `tests/unit/cli/watch-format.test.ts` — verifies `format: 'ts'` reaches `generate`, that omitting it leaves the value `undefined` so the `js` default still applies, and that `--format` is registered on the command. Two of the three fail without the source change.

`yarn test` passes (492 tests, 25 files), `tsc --noEmit` is clean, and `eslint` reports no new warnings.

### Verification

```
$ strapi-types watch --help
  ...
  --format <js|ts>     Output format: js (compiled .js + .d.ts, default) or ts
                       (raw .ts for monorepo/source-tree output) (default: "js")

$ strapi-types watch --output ./src/strapi --format xml
Invalid --format value: xml. Expected 'js' or 'ts'.
```
