### PR TITLE
fix(generator): support unchecked indexed access

### DIFF
--- a/src/generator/client-generator.ts
+++ b/src/generator/client-generator.ts
@@ -816,6 +816,7 @@ function authHeaderValues(headers: Record<string, string>): string[] {
   return Object.keys(headers)
     .filter(k => k.toLowerCase() === 'authorization')
     .map(k => headers[k])
+    .filter(value => value !== undefined)
 }
 
 // Base API class with shared logic

--- a/src/generator/index.ts
+++ b/src/generator/index.ts
@@ -223,6 +223,7 @@ export class Generator {
                 module: ts.ModuleKind.ES2022,
                 moduleResolution: ts.ModuleResolutionKind.Bundler,
                 strict: true,
+                noUncheckedIndexedAccess: true,
                 skipLibCheck: true,
                 noEmit: true,
             })

--- a/tests/unit/generator/generated-typecheck.test.ts
+++ b/tests/unit/generator/generated-typecheck.test.ts
@@ -228,6 +228,7 @@ describe('generated client type-checks clean without @ts-nocheck', () => {
             module: ts.ModuleKind.ESNext,
             moduleResolution: ts.ModuleResolutionKind.Bundler,
             strict: true,
+            noUncheckedIndexedAccess: true,
             skipLibCheck: true,
             noEmit: true,
         })


### PR DESCRIPTION
## Summary

- narrow generated authorization header values after indexed access
- validate generated clients with noUncheckedIndexedAccess enabled
- extend the generated-client regression test to cover strict indexed access

## Verification

- yarn test
- yarn lint
- yarn build